### PR TITLE
Memory leakage and CSV generation - fixed

### DIFF
--- a/common/PlottingImageListener.hpp
+++ b/common/PlottingImageListener.hpp
@@ -196,7 +196,7 @@ public:
     {
         if (faces.empty())
         {
-            fStream << timeStamp << "nan,nan,no,unknown,unknown,unknown,unknown,";
+            fStream << timeStamp << ",nan,nan,no,unknown,unknown,unknown,unknown,";
             for (std::string angle : headAngles) fStream << "nan,";
             for (std::string emotion : emotions) fStream << "nan,";
             for (std::string expression : expressions) fStream << "nan,";
@@ -334,6 +334,7 @@ public:
         cv::putText(img, fps_str, cv::Point(img.cols - 110, img.rows - left_margin), font, font_size, clr);
 
         cv::imshow("analyze video", img);
+        std::lock_guard<std::mutex> lg(mMutex);
         cv::waitKey(30);
     }
 


### PR DESCRIPTION
Minor bug: a comma sign was absent and corrupted CSV-file structure.
Major bug: memory leakage appeared in "video-demo" sample program being run with "--draw 1" parameter. Yo my mind the problem is caused by cv::waitKey() function in multi-threading environment.