### PR TITLE
some misc. tidying

### DIFF
--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -34,19 +34,6 @@ public:
             boost::filesystem::path(".webm"),
             boost::filesystem::path(".wmv"),
             boost::filesystem::path(".mp4"),
-
-            // Supported image formats
-            // check https://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#imread
-            boost::filesystem::path(".bmp"),
-            boost::filesystem::path(".jpeg"),
-            boost::filesystem::path(".jpg"),
-            boost::filesystem::path(".png"),
-            boost::filesystem::path(".pbm"),
-            boost::filesystem::path(".pgm"),
-            boost::filesystem::path(".sr"),
-            boost::filesystem::path(".ras"),
-            boost::filesystem::path(".tiff"),
-            boost::filesystem::path(".tif")
         };
 
         boost::filesystem::path ext = file_path.extension();

--- a/vision/frame-detector-webcam-demo/WebcamDemo.cpp
+++ b/vision/frame-detector-webcam-demo/WebcamDemo.cpp
@@ -19,7 +19,7 @@ using namespace affdex;
 int main(int argsc, char ** argsv) {
     namespace po = boost::program_options; // abbreviate namespace
 
-    std::cerr << "Hit ESCAPE key to exit app.." << endl;
+    std::cout << "Hit ESCAPE key to exit app.." << endl;
 
     try {
 
@@ -49,7 +49,7 @@ int main(int argsc, char ** argsv) {
 #else //  _WIN32
             ("data,d", po::value< affdex::path >(&data_dir)->default_value(affdex::path("data"), std::string("data")), "Path to the data folder")
 #endif // _WIN32
-            ("resolution,r", po::value< std::vector<int> >(&resolution)->default_value(DEFAULT_RESOLUTION, "640 480")->multitoken(), "Resolution in pixels (2-values): width height")
+            ("resolution,r", po::value< std::vector<int> >(&resolution)->default_value(DEFAULT_RESOLUTION, "1280 720")->multitoken(), "Resolution in pixels (2-values): width height")
             ("pfps", po::value< int >(&process_framerate)->default_value(30), "Processing framerate.")
             ("cfps", po::value< int >(&camera_framerate)->default_value(30), "Camera capture framerate.")
             ("cid", po::value< int >(&camera_id)->default_value(0), "Camera ID.")
@@ -121,6 +121,8 @@ int main(int argsc, char ** argsv) {
 
         // Connect to the webcam and configure it
         cv::VideoCapture webcam(camera_id);
+
+        // Note: not all webcams support these configuration properties
         webcam.set(CV_CAP_PROP_FPS, camera_framerate);
         webcam.set(CV_CAP_PROP_FRAME_WIDTH, resolution[0]);
         webcam.set(CV_CAP_PROP_FRAME_HEIGHT, resolution[1]);

--- a/vision/shared/StatusListener.h
+++ b/vision/shared/StatusListener.h
@@ -15,7 +15,7 @@ public:
 
     void onProcessingException(Exception& ex) override
     {
-        print_exception(ex);
+        printException(ex);
         m.lock();
         is_running = false;
         m.unlock();
@@ -32,14 +32,14 @@ public:
 
 private:
     // prints the explanatory string of an exception. If the exception is nested,
-    // recurses to print the explanatory of the exception it holds
-    static void print_exception(const std::exception& e, int level = 0) {
+    // recurses to print the explanatory string of the exception it holds
+    static void printException(const std::exception& e, int level = 0) {
         std::cerr << std::string(level, ' ') << "exception: " << e.what() << '\n';
         try {
             std::rethrow_if_nested(e);
         }
         catch (const std::exception& e) {
-            print_exception(e, level + 1);
+            printException(e, level + 1);
         }
         catch (...) {}
     }

--- a/vision/shared/Visualizer.h
+++ b/vision/shared/Visualizer.h
@@ -61,11 +61,11 @@ public:
 private:
 
     /**
-    * Overlay an image with an Alpha (foreground) channel over background
-    * Assumes foreground.size() == background.size()
+    * Overlay an image with an Alpha (foreground) channel over background at a specified location
     * Adapted from : http://jepsonsblog.blogspot.com/2012/10/overlay-transparent-image-in-opencv.html
     * @param foreground - image to overlay
-    * @param background - ROI to overlay on
+    * @param background - background image
+    * @param location   - location on the background image where the foreground image should be placed
     */
     void overlayImage(const cv::Mat &foreground, cv::Mat &background, cv::Point2i location);
 


### PR DESCRIPTION
- remove image file format support from VideoDemo.cpp (images not supported
  in auto SDK)
- in WebcamDemo.cpp, output message about hitting ESC to cout instead of
  cerr
- in WebcamDemo.cpp, fix description of default resolution
- in StatusListener.h, change print_exception method name to camel case
- in Visualizer.h, fix doc comment for overlayImage method