### PR TITLE
sdk-2051

### DIFF
--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -150,13 +150,13 @@ public:
 
             std::map<vision::FacePoint, vision::Point> points = f.getFacePoints();
 
-            // Draw Facial Landmarks Points
-            viz.drawPoints(f.getFacePoints());
-
             // Draw bounding box
             auto bbox = f.getBoundingBox();
             const float valence = f.getEmotions().at(vision::Emotion::VALENCE);
             viz.drawBoundingBox(bbox, valence);
+
+            // Draw Facial Landmarks Points
+            viz.drawPoints(f.getFacePoints());
 
             // Draw a face on screen
             viz.drawFaceMetrics(f, bbox, draw_face_id);


### PR DESCRIPTION
We were experiencing an issue where the chin point was being hidden
behind the bounding box except at extreme face angles. This fix just draws the landmark points after the bounding box so they aren't covered up. 

