### PR TITLE
Sdk 2322 (minimize/eliminate compiler warnings)

### DIFF
--- a/vision/CMakeLists.txt
+++ b/vision/CMakeLists.txt
@@ -15,6 +15,9 @@ CONFIG_COMPILER_11()
 CONFIG_LINKER()
 SETUP_INSTALL_DIRS()
 
+# SUPRRESS DEPRECATION WARNINGS 
+add_compile_options(-Wno-deprecated -Wno-deprecated-declarations)
+
 # --------------------
 # DEPENDENCIES
 # --------------------

--- a/vision/README.md
+++ b/vision/README.md
@@ -1,5 +1,5 @@
 # Sample apps for analyzing facial emotion using Affectiva's Automotive SDK for Linux
-###frame-detector-webcam-demo
+### frame-detector-webcam-demo
 
 This sample demonstrates use of the [FrameDetector class](https://auto.affectiva.com/docs/vision-create-detector), getting its input from a webcam. It analyzes received frames and displays the results on screen.
 
@@ -7,7 +7,7 @@ After building, run the command `./frame-detector-webcam-demo --help` for inform
 
 ---
 
-###frame-detector-video-demo
+### frame-detector-video-demo
 
 This sample demonstrates use of the [FrameDetector class](https://auto.affectiva.com/docs/vision-create-detector), getting its input from a video file. It analyzes received frames and displays the results on screen.
 
@@ -24,7 +24,8 @@ The Vision Library is packaged with the Automotive SDK, which is available upon 
 #### Additional Dependencies
 
 Install additional dependencies with the following command:  
-Ubuntu:`$ sudo apt-get install -y build-essential libopencv-dev cmake libgtk2.0-dev pkg-config libjpeg-dev libpng-dev libtiff-dev libavformat-dev libavcodec-dev libswscale-dev`
+Ubuntu:`$ sudo apt install -y git pip build-essential libopencv-dev cmake libgtk2.0-dev pkg-config libjpeg-dev libpng-dev libtiff-dev libavformat-dev libavcodec-dev libswscale-dev`  
+Ubuntu: `$ pip install numpy`
 
 [Click here](#ubuntu-18) for instructions on building sample apps for Ubuntu 18.
 
@@ -35,7 +36,7 @@ Ubuntu:`$ sudo apt-get install -y build-essential libopencv-dev cmake libgtk2.0-
 ### Boost
 Install boost directly from the package manager with the following command:   
 
-Ubuntu: `$ sudo apt-get install -y libboost-dev libboost-filesystem1.65-dev libboost-program-options1.65-dev libboost-system1.65-dev`
+Ubuntu: `$ sudo apt install -y libboost-dev libboost-filesystem1.65-dev libboost-program-options1.65-dev libboost-system1.65-dev`
 
 ### OpenCV  
 We do not recommend running the sample apps with OpenCV 3.2.0 from the package manager. Instead, you must build opencv 2.4.13 from source. Other OpenCV versions 2.4.** may work but we recommend 2.4.13 as a tested depedency for the sample apps on Ubuntu 18.
@@ -130,7 +131,7 @@ $ sudo ./b2 -j $(nproc) cxxflags=-fPIC threading=multi runtime-link=shared \
 ### OpenCV
 Install OpenCV directly from the package manager with the following command:
 
-`$ sudo apt-get install -y libopencv-dev`
+`$ sudo apt install -y libopencv-dev`
 
 ### Building with CMake
 
@@ -152,7 +153,7 @@ cd vision-samples-build
 CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release \
 -DAFFECTIVA_SDK_DIR=/path/to/auto-sdk \
 -DBOOST_ROOT=/path/to/boost-build \
--DOpenCV_DIR=/usr \
+-DOpenCV_DIR=/usr/ \
 -DCMAKE_INSTALL_PREFIX=/path/to/cpp-sdk-samples/vision/vision-samples-install"
 
 cmake $CMAKE_ARGS /path/to/cpp-sdk-samples/vision 

--- a/vision/README.md
+++ b/vision/README.md
@@ -1,7 +1,7 @@
 # Sample apps for analyzing facial emotion using Affectiva's Automotive SDK for Linux
 ### frame-detector-webcam-demo
 
-This sample demonstrates use of the [FrameDetector class](https://auto.affectiva.com/docs/vision-create-detector), getting its input from a webcam. It analyzes received frames and displays the results on screen.
+This sample demonstrates use of the SyncFrameDetector class, getting its input from a webcam. It analyzes received frames and displays the results on screen.
 
 After building, run the command `./frame-detector-webcam-demo --help` for information on its command line options.
 
@@ -9,7 +9,7 @@ After building, run the command `./frame-detector-webcam-demo --help` for inform
 
 ### frame-detector-video-demo
 
-This sample demonstrates use of the [FrameDetector class](https://auto.affectiva.com/docs/vision-create-detector), getting its input from a video file. It analyzes received frames and displays the results on screen.
+This sample demonstrates use of the SyncFrameDetector class, getting its input from a video file. It analyzes received frames and displays the results on screen.
 
 After building, run the command `./frame-detector-video-demo --help` for information on its command line options.
 
@@ -24,12 +24,11 @@ The Vision Library is packaged with the Automotive SDK, which is available upon 
 #### Additional Dependencies
 
 Install additional dependencies with the following command:  
-Ubuntu:`$ sudo apt install -y git pip build-essential libopencv-dev cmake libgtk2.0-dev pkg-config libjpeg-dev libpng-dev libtiff-dev libavformat-dev libavcodec-dev libswscale-dev`  
-Ubuntu: `$ pip install numpy`
+Ubuntu:`$ sudo apt install -y wget git build-essential libopencv-dev cmake libgtk2.0-dev pkg-config libjpeg-dev libpng-dev libtiff-dev libavformat-dev libavcodec-dev libswscale-dev`  
 
 [Click here](#ubuntu-18) for instructions on building sample apps for Ubuntu 18.
 
-[Click here](#ubuntu-16) for instruction on building sample apps for Ubuntu 16. 
+[Click here](#ubuntu-16) for instruction on building sample apps for Ubuntu 16.
 
 ## Ubuntu 18  
 
@@ -72,20 +71,20 @@ mkdir build install
 cd build
 
 CMAKE_ARGS="-DWITH_FFMPEG=ON \
--DBUILD_TESTS=OFF \ 
--DBUILD_PERF_TESTS=OFF \ 
--DCMAKE_BUILD_TYPE=RELEASE \ 
+-DBUILD_TESTS=OFF \
+-DBUILD_PERF_TESTS=OFF \
+-DCMAKE_BUILD_TYPE=RELEASE \
 -DENABLE_PRECOMPILED_HEADERS=OFF \
 -DCMAKE_INSTALL_PREFIX=/path/to/opencv/install"
 
 cmake $CMAKE_ARGS ../
-make -j4 
-make install 
+make -j4
+make install
 ```
 ----
 ### Building Samples with CMake
 
-Specify the the following CMake variables to identify the locations of various dependencies:
+Specify the following CMake variables to identify the locations of various dependencies:
 
 - **AFFECTIVA_SDK_DIR**: set path to the folder where the Automotive SDK is installed (`/path/to/auto-sdk`)
 - **BOOST_ROOT**: set path to the `/usr/` directory
@@ -105,18 +104,23 @@ CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release \
 -DOpenCV_DIR=/path/to/opencv/install/share/OpenCV \
 -DCMAKE_INSTALL_PREFIX=/path/to/cpp-sdk-samples/vision/vision-samples-install"
 
-cmake $CMAKE_ARGS /path/to/cpp-sdk-samples/vision 
+cmake $CMAKE_ARGS /path/to/cpp-sdk-samples/vision
 make -j4
 make install
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$AFFECTIVA_SDK_DIR/lib
+```
+Setup runtime configurations by running the `config.sh` bash script with the following commands:
+```
+$ export AFFECTIVA_SDK_DIR=/path/to/auto-sdk
+$ ../config.sh
+
 ```
 
 ---
 
 ## Ubuntu 16
 
-### Boost 
+### Boost
 ```
 $ mkdir boost-build
 $ cd boost-build
@@ -156,7 +160,7 @@ CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release \
 -DOpenCV_DIR=/usr/ \
 -DCMAKE_INSTALL_PREFIX=/path/to/cpp-sdk-samples/vision/vision-samples-install"
 
-cmake $CMAKE_ARGS /path/to/cpp-sdk-samples/vision 
+cmake $CMAKE_ARGS /path/to/cpp-sdk-samples/vision
 make -j4
 make install
 

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -22,9 +22,9 @@ public:
     PlottingImageListener(std::ofstream &csv, bool draw_display, bool enable_logging, bool draw_face_id) :
         draw_display(draw_display),
         capture_last_ts(0),
-        capture_fps(-1),
+        capture_fps(0),
         process_last_ts(0),
-        process_fps(-1),
+        process_fps(0),
         out_stream(csv),
         start(std::chrono::system_clock::now()),
         processed_frames(0),
@@ -189,9 +189,9 @@ public:
     void reset() {
         std::lock_guard<std::mutex> lg(mtx);
         capture_last_ts = 0;
-        capture_fps = unsigned(-1.0);
+        capture_fps = 0;
         process_last_ts = 0;
-        process_fps = unsigned(-1.0);
+        process_fps = 0;
         start = std::chrono::system_clock::now();
         processed_frames = 0;
         frames_with_faces = 0;

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -189,9 +189,9 @@ public:
     void reset() {
         std::lock_guard<std::mutex> lg(mtx);
         capture_last_ts = 0;
-        capture_fps = -1.0f;
+        capture_fps = unsigned(-1.0);
         process_last_ts = 0;
-        process_fps = -1.0f;
+        process_fps = unsigned(-1.0);
         start = std::chrono::system_clock::now();
         processed_frames = 0;
         frames_with_faces = 0;


### PR DESCRIPTION
The goal of this story was to remove warning messages at compile time since they give a bad impression to clients. Many of these warnings were deprecation warnings while the rest related to overflow warnings. 
**Changes Made**
-set flags in CMakeLists.txt to suppress deprecation warnings 
- change initialization and reset of capture_fps and process_fps to zero instead of -1 (which is a large value since they are initialized as unsigned ints)