### PR TITLE
Sdk 3671

### DIFF
--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -105,7 +105,7 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
              << "Object types detected: " << object_listener.getObjectTypesDetected() << endl
              << "Objects detected in regions: " << object_listener.getObjectRegionsDetected() << endl
              << "Object callback interval: " << object_listener.getCallBackInterval() << endl
-             << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
+             << "Average processed fps: " << timer.count * 1000.0f / timer.total_elapsed_time << "\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -158,7 +158,7 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
         cout << "******************************************************************\n"
              << "Occupants detected in regions:  " << occupant_listener.getOccupantRegionsDetected() << endl
              << "Occupant callback interval: " << occupant_listener.getCallbackInterval() << "ms\n"
-             << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
+             << "Average processed fps: " << timer.count * 1000.0f / timer.total_elapsed_time << "\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -208,7 +208,7 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
 
         cout << "******************************************************************\n"
              << "Body callback interval: " << body_listener.getCallbackInterval() << "ms\n"
-             << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
+             << "Average processed fps: " << timer.count * 1000.0f / timer.total_elapsed_time << "\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -266,7 +266,7 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
              << "Processed Frame count: " << image_listener.getProcessedFrames() << endl
              << "Frames w/faces: " << image_listener.getFramesWithFaces() << endl
              << "Percent of frames w/faces: " << image_listener.getFramesWithFacesPercent() << "%\n"
-             << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
+             << "Average processed fps: " << timer.count * 1000.0f / timer.total_elapsed_time << "\n"
              << "******************************************************************\n";
 
         detector.reset();

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -112,6 +112,8 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
              << "Object types detected: " << object_listener.getObjectTypesDetected() << endl
              << "Objects detected in regions " << object_listener.getObjectRegionsDetected() << endl
              << "Object callback interval: " << object_listener.getCallBackInterval() << endl
+             << "Frames processed per second: "
+             << object_listener.getProcessedFrames() * 1.0f / object_listener.getTotalTimeToProcessFrames() << endl
              << "******************************************************************\n";
 
         detector.reset();
@@ -166,6 +168,8 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
              << "%\n"
              << "Occupants detected in regions:  " << occupant_listener.getOccupantRegionsDetected() << endl
              << "Occupant callback interval: " << occupant_listener.getCallbackInterval() << "ms\n"
+             << "Frames processed per second: "
+             << occupant_listener.getProcessedFrames() * 1.0f / occupant_listener.getTotalTimeToProcessFrames() << endl
              << "******************************************************************\n";
 
         detector.reset();
@@ -218,6 +222,8 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
              << "Percent of samples w/bodies present: " << body_listener.getSamplesWithBodiesPercent()
              << "%\n"
              << "Body callback interval: " << body_listener.getCallbackInterval() << "ms\n"
+             << "Frames processed per second: "
+             << body_listener.getProcessedFrames() * 1.0f / body_listener.getTotalTimeToProcessFrames() << endl
              << "******************************************************************\n";
 
         detector.reset();
@@ -248,7 +254,6 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
     // start the detector
     detector.start();
 
-
     do {
         // the VideoReader will handle decoding frames from the input video file
         VideoReader video_reader(program_options.input_video_path);
@@ -276,6 +281,8 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
              << "Processed Frame count: " << image_listener.getProcessedFrames() << endl
              << "Frames w/faces: " << image_listener.getFramesWithFaces() << endl
              << "Percent of frames w/faces: " << image_listener.getFramesWithFacesPercent() << "%\n"
+             << "Frames processed per second: " <<
+             image_listener.getProcessedFrames() * 1.0f / image_listener.getTotalTimeToProcessFrames() << endl
              << "******************************************************************\n";
 
         detector.reset();
@@ -401,9 +408,12 @@ int main(int argsc, char** argsv) {
         }
 
         //Get resolution and fps from input video
-        float sniffed_fps;
-        int frameHeight, frameWidth;
-        VideoReader::SniffResolution(program_options.input_video_path, frameHeight, frameWidth, sniffed_fps);
+        cv::VideoCapture video(program_options.input_video_path);
+        float sniffed_fps = video.get(CV_CAP_PROP_FPS);
+        int frameHeight = video.get(CV_CAP_PROP_FRAME_HEIGHT);
+        int frameWidth = video.get(CV_CAP_PROP_FRAME_WIDTH);
+        video.release();
+        //VideoReader::SniffResolution(program_options.input_video_path, frameHeight, frameWidth, sniffed_fps);
         if (program_options.sampling_frame_rate <= 0) {
             // If user did not specify --sfps (i.e. // default of 0), used the sniffed_fps
             program_options.sampling_frame_rate = sniffed_fps;

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -98,7 +98,7 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
             detector.process(f);
             object_listener.processResults(f);
 
-            std::cout << "Screen-FPS: " << object_listener.getInstantaneousFrameRate() << " Processing-FPS: " << object_listener.getProcessingFrameRate() << std::endl;
+            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << object_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {
@@ -153,7 +153,7 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
             detector.process(f);
             occupant_listener.processResults(f);
 
-            std::cout << "Screen-FPS: " << occupant_listener.getInstantaneousFrameRate() << " Processing-FPS: " << occupant_listener.getProcessingFrameRate() << std::endl;
+            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << occupant_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {
@@ -206,7 +206,7 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
             detector.process(f);
             body_listener.processResults(f);
 
-            std::cout << "Screen-FPS: " << body_listener.getInstantaneousFrameRate() << " Processing-FPS: " << body_listener.getProcessingFrameRate() << std::endl;
+            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << body_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {
@@ -264,7 +264,7 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
             detector.process(f);
             image_listener.processResults(f);
 
-            std::cout << "Screen-FPS: " << image_listener.getInstantaneousFrameRate() << " Processing-FPS: " << image_listener.getProcessingFrameRate() << std::endl;
+            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << image_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -43,8 +43,7 @@ void assembleProgramOptions(po::options_description& description, ProgramOptions
         ("input,i", po::value<affdex::Path>(&program_options.input_video_path)->required(), "Video file to processs")
         ("output,o", po::value<affdex::Path>(&program_options.output_video_path), "Output video path.")
 #endif // _WIN32
-        ("sfps",
-         po::value<float>(&program_options.sampling_frame_rate)->default_value(0),
+        ("sfps", po::value<int>(&program_options.sampling_frame_rate)->default_value(0),
          "Input sampling frame rate. Default is 0, which means the app will respect the video's FPS and read all frames")
         ("draw", po::value<bool>(&program_options.draw_display)->default_value(true), "Draw video on screen.")
         ("numFaces", po::value<unsigned int>(&program_options.num_faces)->default_value(5), "Number of faces to be "
@@ -53,8 +52,7 @@ void assembleProgramOptions(po::options_description& description, ProgramOptions
         ("face_id",
          po::bool_switch(&program_options.draw_id)->default_value(false),
          "Draw face id on screen. Note: Drawing to screen should be enabled.")
-        ("quiet,q",
-         po::bool_switch(&program_options.disable_logging)->default_value(false),
+        ("quiet,q", po::bool_switch(&program_options.disable_logging)->default_value(false),
          "Disable logging to console")
         ("object", "Enable object detection")
         ("occupant", "Enable occupant detection, also enables body and face detection")

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -98,8 +98,6 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
             detector.process(f);
             object_listener.processResults(f);
 
-            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << object_listener.getProcessingFrameRate() << std::endl;
-
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << object_listener.getImageData();
@@ -155,8 +153,6 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
             detector.process(f);
             occupant_listener.processResults(f);
 
-            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << occupant_listener.getProcessingFrameRate() << std::endl;
-
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << occupant_listener.getImageData();
@@ -209,8 +205,6 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
             body_listener.startTimer();
             detector.process(f);
             body_listener.processResults(f);
-
-            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << body_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {
@@ -268,8 +262,6 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
             image_listener.startTimer();
             detector.process(f);
             image_listener.processResults(f);
-
-            std::cout << "Timestamp: " << timestamp_ms << " Processing-FPS: " << image_listener.getProcessingFrameRate() << std::endl;
 
             //To save output video file
             if (program_options.write_video) {

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -110,8 +110,9 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
              << "Object types detected: " << object_listener.getObjectTypesDetected() << endl
              << "Objects detected in regions " << object_listener.getObjectRegionsDetected() << endl
              << "Object callback interval: " << object_listener.getCallBackInterval() << endl
-             << "Frames processed per second: "
-             << object_listener.getProcessedFrames() * 1.0f / object_listener.getTotalTimeToProcessFrames() << endl
+             << "Average processed fps: "
+             << object_listener.totalFramesCount() * 1.0f / object_listener.getTotalTimeToProcessFrames()
+             << " (detector ran every " << object_listener.getCallBackInterval()<< ")\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -164,8 +165,9 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
              << "%\n"
              << "Occupants detected in regions:  " << occupant_listener.getOccupantRegionsDetected() << endl
              << "Occupant callback interval: " << occupant_listener.getCallbackInterval() << "ms\n"
-             << "Frames processed per second: "
-             << occupant_listener.getProcessedFrames() * 1.0f / occupant_listener.getTotalTimeToProcessFrames() << endl
+             << "Average processed fps: "
+             << occupant_listener.totalFramesCount() * 1.0f / occupant_listener.getTotalTimeToProcessFrames()
+             << " (detector ran every " << occupant_listener.getCallbackInterval()<< "ms)\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -216,8 +218,9 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
              << "Percent of samples w/bodies present: " << body_listener.getSamplesWithBodiesPercent()
              << "%\n"
              << "Body callback interval: " << body_listener.getCallbackInterval() << "ms\n"
-             << "Frames processed per second: "
-             << body_listener.getProcessedFrames() * 1.0f / body_listener.getTotalTimeToProcessFrames() << endl
+             << "Average processed fps: "
+             << body_listener.totalFramesCount() * 1.0f / body_listener.getTotalTimeToProcessFrames()
+             << " (detector ran every " << body_listener.getCallbackInterval()<< "ms)\n"
              << "******************************************************************\n";
 
         detector.reset();
@@ -273,8 +276,8 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
              << "Processed Frame count: " << image_listener.getProcessedFrames() << endl
              << "Frames w/faces: " << image_listener.getFramesWithFaces() << endl
              << "Percent of frames w/faces: " << image_listener.getFramesWithFacesPercent() << "%\n"
-             << "Frames processed per second: " <<
-             image_listener.getProcessedFrames() * 1.0f / image_listener.getTotalTimeToProcessFrames() << endl
+             << "Average processed fps: " <<
+             image_listener.totalFramesCount() * 1.0f / image_listener.getTotalTimeToProcessFrames() << endl
              << "******************************************************************\n";
 
         detector.reset();

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
+
 #include <iostream>
 #include <iomanip>
 
@@ -93,8 +94,12 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
             // create a Frame from the video input and process it with the Detector
             vision::Frame
                 f(mat.size().width, mat.size().height, mat.data, vision::Frame::ColorFormat::BGR, timestamp_ms);
+            object_listener.startTimer();
             detector.process(f);
             object_listener.processResults(f);
+
+            std::cout << "Screen-FPS: " << object_listener.getInstantaneousFrameRate() << " Processing-FPS: " << object_listener.getProcessingFrameRate() << std::endl;
+
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << object_listener.getImageData();
@@ -144,8 +149,12 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
             // create a Frame from the video input and process it with the Detector
             vision::Frame
                 f(mat.size().width, mat.size().height, mat.data, vision::Frame::ColorFormat::BGR, timestamp_ms);
+            occupant_listener.startTimer();
             detector.process(f);
             occupant_listener.processResults(f);
+
+            std::cout << "Screen-FPS: " << occupant_listener.getInstantaneousFrameRate() << " Processing-FPS: " << occupant_listener.getProcessingFrameRate() << std::endl;
+
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << occupant_listener.getImageData();
@@ -192,8 +201,13 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
             // create a Frame from the video input and process it with the Detector
             vision::Frame
                 f(mat.size().width, mat.size().height, mat.data, vision::Frame::ColorFormat::BGR, timestamp_ms);
+
+            body_listener.startTimer();
             detector.process(f);
             body_listener.processResults(f);
+
+            std::cout << "Screen-FPS: " << body_listener.getInstantaneousFrameRate() << " Processing-FPS: " << body_listener.getProcessingFrameRate() << std::endl;
+
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << body_listener.getImageData();
@@ -234,6 +248,7 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
     // start the detector
     detector.start();
 
+
     do {
         // the VideoReader will handle decoding frames from the input video file
         VideoReader video_reader(program_options.input_video_path, program_options.sampling_frame_rate);
@@ -244,8 +259,13 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
             // create a Frame from the video input and process it with the Detector
             vision::Frame
                 f(mat.size().width, mat.size().height, mat.data, vision::Frame::ColorFormat::BGR, timestamp_ms);
+
+            image_listener.startTimer();
             detector.process(f);
             image_listener.processResults(f);
+
+            std::cout << "Screen-FPS: " << image_listener.getInstantaneousFrameRate() << " Processing-FPS: " << image_listener.getProcessingFrameRate() << std::endl;
+
             //To save output video file
             if (program_options.write_video) {
                 program_options.output_video << image_listener.getImageData();

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -15,7 +15,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
-
 #include <iostream>
 #include <iomanip>
 
@@ -58,7 +57,6 @@ void assembleProgramOptions(po::options_description& description, ProgramOptions
         ("occupant", "Enable occupant detection, also enables body and face detection")
         ("body", "Enable body detection")
         ("drowsiness", "Enable drowsiness detection, will be used only if no other detection types are enabled");
-
 }
 
 void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_file_stream,
@@ -104,8 +102,6 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
         }
 
         cout << "******************************************************************\n"
-             << "Percent of samples w/objects present: " << object_listener.getSamplesWithObjectsPercent() << "%"
-             << endl
              << "Object types detected: " << object_listener.getObjectTypesDetected() << endl
              << "Objects detected in regions: " << object_listener.getObjectRegionsDetected() << endl
              << "Object callback interval: " << object_listener.getCallBackInterval() << endl
@@ -126,7 +122,8 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
     detector.enable(vision::Feature::OCCUPANTS);
 
     // prepare listeners
-    PlottingOccupantListener occupant_listener(csv_file_stream, program_options, 500, detector.getCabinRegionConfig().getRegions());
+    PlottingOccupantListener
+        occupant_listener(csv_file_stream, program_options, 500, detector.getCabinRegionConfig().getRegions());
     StatusListener status_listener;
 
     // configure the Detector by assigning listeners
@@ -159,12 +156,10 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
         }
 
         cout << "******************************************************************\n"
-             << "Percent of samples w/occupants present: " << occupant_listener.getSamplesWithOccupantsPercent()
-             << "%\n"
              << "Occupants detected in regions:  " << occupant_listener.getOccupantRegionsDetected() << endl
              << "Occupant callback interval: " << occupant_listener.getCallbackInterval() << "ms\n"
              << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
-            << "******************************************************************\n";
+             << "******************************************************************\n";
 
         detector.reset();
         occupant_listener.reset();
@@ -212,7 +207,6 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
         }
 
         cout << "******************************************************************\n"
-             << "Percent of samples w/bodies present: " << body_listener.getSamplesWithBodiesPercent() << "%\n"
              << "Body callback interval: " << body_listener.getCallbackInterval() << "ms\n"
              << "Average processed fps: " << timer.count_ * 1000.0f / timer.total_elapsed_time_ << "\n"
              << "******************************************************************\n";
@@ -229,8 +223,8 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
     detector.enable({vision::Feature::EMOTIONS, vision::Feature::EXPRESSIONS, vision::Feature::IDENTITY,
                      vision::Feature::APPEARANCES, vision::Feature::GAZE});
 
-    if(program_options.show_drowsiness) {
-        detector.enable( vision::Feature::DROWSINESS);
+    if (program_options.show_drowsiness) {
+        detector.enable(vision::Feature::DROWSINESS);
     }
 
     // prepare listeners
@@ -313,8 +307,9 @@ bool verifyTypeOfProcess(const po::variables_map& args,
         //check for drowsiness only when faces are enabled
         program_options.show_drowsiness = args.count("drowsiness");
         //append _drowsiness to csv file
-        if(program_options.show_drowsiness)
+        if (program_options.show_drowsiness) {
             detection_type_str += "_drowsiness";
+        }
         std::cout << "Setting up face detection\n";
     }
     return true;

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -43,7 +43,7 @@ void assembleProgramOptions(po::options_description& description, ProgramOptions
         ("output,o", po::value<affdex::Path>(&program_options.output_video_path), "Output video path.")
 #endif // _WIN32
         ("sfps",
-         po::value<unsigned int>(&program_options.sampling_frame_rate)->default_value(0),
+         po::value<float>(&program_options.sampling_frame_rate)->default_value(-1.0f),
          "Input sampling frame rate. Default is 0, which means the app will respect the video's FPS and read all frames")
         ("draw", po::value<bool>(&program_options.draw_display)->default_value(true), "Draw video on screen.")
         ("numFaces", po::value<unsigned int>(&program_options.num_faces)->default_value(5), "Number of faces to be "
@@ -86,7 +86,7 @@ void processObjectVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_
 
     do {
         // the VideoReader will handle decoding frames from the input video file
-        VideoReader video_reader(program_options.input_video_path, program_options.sampling_frame_rate);
+        VideoReader video_reader(program_options.input_video_path);
 
         cv::Mat mat;
         Timestamp timestamp_ms;
@@ -141,7 +141,7 @@ void processOccupantVideo(vision::SyncFrameDetector& detector, std::ofstream& cs
 
     do {
         // the VideoReader will handle decoding frames from the input video file
-        VideoReader video_reader(program_options.input_video_path, program_options.sampling_frame_rate);
+        VideoReader video_reader(program_options.input_video_path);
 
         cv::Mat mat;
         Timestamp timestamp_ms;
@@ -193,7 +193,7 @@ void processBodyVideo(vision::SyncFrameDetector& detector, std::ofstream& csv_fi
 
     do {
         // the VideoReader will handle decoding frames from the input video file
-        VideoReader video_reader(program_options.input_video_path, program_options.sampling_frame_rate);
+        VideoReader video_reader(program_options.input_video_path);
 
         cv::Mat mat;
         Timestamp timestamp_ms;
@@ -251,7 +251,7 @@ void processFaceVideo(vision::SyncFrameDetector& detector,
 
     do {
         // the VideoReader will handle decoding frames from the input video file
-        VideoReader video_reader(program_options.input_video_path, program_options.sampling_frame_rate);
+        VideoReader video_reader(program_options.input_video_path);
 
         cv::Mat mat;
         Timestamp timestamp_ms;
@@ -401,12 +401,13 @@ int main(int argsc, char** argsv) {
         }
 
         //Get resolution and fps from input video
-        int sniffed_fps, frameHeight, frameWidth;
+        float sniffed_fps;
+        int frameHeight, frameWidth;
         VideoReader::SniffResolution(program_options.input_video_path, frameHeight, frameWidth, sniffed_fps);
-        if (program_options.sampling_frame_rate == 0) {
+        if (program_options.sampling_frame_rate <= 0) {
             // If user did not specify --sfps (i.e. // default of 0), used the sniffed_fps
             program_options.sampling_frame_rate = sniffed_fps;
-            std::cout << "Using estimated video FPS for output video: " << sniffed_fps;
+            std::cout << "Using estimated video FPS for output video: " << sniffed_fps <<std::endl;
         }
 
         //Setup video writer

--- a/vision/frame-detector-video-demo/VideoDemo.cpp
+++ b/vision/frame-detector-video-demo/VideoDemo.cpp
@@ -409,11 +409,10 @@ int main(int argsc, char** argsv) {
 
         //Get resolution and fps from input video
         cv::VideoCapture video(program_options.input_video_path);
-        float sniffed_fps = video.get(CV_CAP_PROP_FPS);
-        int frameHeight = video.get(CV_CAP_PROP_FRAME_HEIGHT);
-        int frameWidth = video.get(CV_CAP_PROP_FRAME_WIDTH);
+        auto sniffed_fps = static_cast<float>(video.get(CV_CAP_PROP_FPS));
+        int frameHeight = static_cast<int>(video.get(CV_CAP_PROP_FRAME_HEIGHT));
+        int frameWidth = static_cast<int>(video.get(CV_CAP_PROP_FRAME_WIDTH));
         video.release();
-        //VideoReader::SniffResolution(program_options.input_video_path, frameHeight, frameWidth, sniffed_fps);
         if (program_options.sampling_frame_rate <= 0) {
             // If user did not specify --sfps (i.e. // default of 0), used the sniffed_fps
             program_options.sampling_frame_rate = sniffed_fps;

--- a/vision/frame-detector-webcam-demo/WebcamDemo.cpp
+++ b/vision/frame-detector-webcam-demo/WebcamDemo.cpp
@@ -48,7 +48,7 @@ void assembleProgramOptions(po::options_description& description, ProgramOptions
          po::value<std::vector<int>
          >(&program_options.resolution)->default_value(DEFAULT_RESOLUTION, "1280 720")->multitoken(),
          "Resolution in pixels (2-values): width height")
-        ("pfps", po::value<int>(&program_options.process_framerate)->default_value(30), "Processing framerate.")
+        ("pfps", po::value<float>(&program_options.process_framerate)->default_value(30.f), "Processing framerate.")
         ("cfps", po::value<int>(&program_options.camera_framerate)->default_value(30), "Camera capture framerate.")
         ("cid", po::value<int>(&program_options.camera_id)->default_value(0), "Camera ID.")
         ("numFaces",

--- a/vision/frame-detector-webcam-demo/WebcamDemo.cpp
+++ b/vision/frame-detector-webcam-demo/WebcamDemo.cpp
@@ -121,7 +121,6 @@ bool processFrameFromWebcam(std::unique_ptr<vision::Detector>& frame_detector, P
 
     // Create a Frame from the webcam image and process it with the Detector
     frame = vision::Frame(img.size().width, img.size().height, img.data, vision::Frame::ColorFormat::BGR, ts);
-
     if (program_options.sync) {
         dynamic_cast<vision::SyncFrameDetector*>(frame_detector.get())->process(frame);
     }

--- a/vision/frame-detector-webcam-demo/WebcamDemo.cpp
+++ b/vision/frame-detector-webcam-demo/WebcamDemo.cpp
@@ -155,7 +155,6 @@ void processFaceStream(std::unique_ptr<vision::Detector>& frame_detector, std::o
     try {
         vision::Frame frame;
         do {
-            image_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -183,9 +182,7 @@ void processObjectStream(std::unique_ptr<vision::Detector>& frame_detector, std:
 
     // prepare listeners
     PlottingObjectListener object_listener(csv_file_stream,
-                                           program_options.draw_display,
-                                           !program_options.disable_logging,
-                                           program_options.draw_id,
+                                           program_options,
                                            {{vision::Feature::CHILD_SEATS, 1000}, {vision::Feature::PHONES, 1000}},
                                            frame_detector->getCabinRegionConfig().getRegions());
 
@@ -203,7 +200,6 @@ void processObjectStream(std::unique_ptr<vision::Detector>& frame_detector, std:
     try {
         vision::Frame frame;
         do {
-            object_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -232,8 +228,7 @@ void processOccupantStream(std::unique_ptr<vision::Detector>& frame_detector,
                            cv::VideoCapture& webcam) {
 
     // prepare listeners
-    PlottingOccupantListener occupant_listener(csv_file_stream, program_options.draw_display, !program_options
-        .disable_logging, program_options.draw_id, 200, frame_detector->getCabinRegionConfig().getRegions());
+    PlottingOccupantListener occupant_listener(csv_file_stream, program_options, 200, frame_detector->getCabinRegionConfig().getRegions());
 
 
     // configure the Detector by enabling features and assigning listeners
@@ -251,7 +246,6 @@ void processOccupantStream(std::unique_ptr<vision::Detector>& frame_detector,
     try {
         vision::Frame frame;
         do {
-            occupant_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -281,8 +275,7 @@ void processBodyStream(std::unique_ptr<vision::Detector>& frame_detector,
                            cv::VideoCapture& webcam) {
 
     // prepare listeners
-    PlottingBodyListener body_listener(csv_file_stream, program_options.draw_display, !program_options
-        .disable_logging, program_options.draw_id, 500);
+    PlottingBodyListener body_listener(csv_file_stream, program_options, 500);
 
 
     // configure the Detector by enabling features and assigning listeners
@@ -298,7 +291,6 @@ void processBodyStream(std::unique_ptr<vision::Detector>& frame_detector,
     try {
         vision::Frame frame;
         do {
-            body_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }

--- a/vision/frame-detector-webcam-demo/WebcamDemo.cpp
+++ b/vision/frame-detector-webcam-demo/WebcamDemo.cpp
@@ -121,6 +121,7 @@ bool processFrameFromWebcam(std::unique_ptr<vision::Detector>& frame_detector, P
 
     // Create a Frame from the webcam image and process it with the Detector
     frame = vision::Frame(img.size().width, img.size().height, img.data, vision::Frame::ColorFormat::BGR, ts);
+
     if (program_options.sync) {
         dynamic_cast<vision::SyncFrameDetector*>(frame_detector.get())->process(frame);
     }
@@ -155,6 +156,7 @@ void processFaceStream(std::unique_ptr<vision::Detector>& frame_detector, std::o
     try {
         vision::Frame frame;
         do {
+            image_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -202,6 +204,7 @@ void processObjectStream(std::unique_ptr<vision::Detector>& frame_detector, std:
     try {
         vision::Frame frame;
         do {
+            object_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -249,6 +252,7 @@ void processOccupantStream(std::unique_ptr<vision::Detector>& frame_detector,
     try {
         vision::Frame frame;
         do {
+            occupant_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }
@@ -295,6 +299,7 @@ void processBodyStream(std::unique_ptr<vision::Detector>& frame_detector,
     try {
         vision::Frame frame;
         do {
+            body_listener.startTimer();
             if (!processFrameFromWebcam(frame_detector, program_options, webcam, start_time, frame)) {
                 break;
             }

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -119,7 +119,9 @@ public:
             viz_.drawBodyMetrics(body_points);
         }
 
-        viz_.showImage();
+        if (draw_display_) {
+            viz_.showImage();
+        }
         image_data_ = viz_.getImageData();
     }
 

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -74,9 +74,8 @@ public:
     void onBodyResults(const std::map<vision::BodyId, vision::Body>& bodies,
                        vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
+        stopTimer(frame.getTimestamp());
         results_.emplace_back(frame, bodies);
-        process_last_ts_ = frame.getTimestamp();
-
         ++processed_frames_;
         if (!bodies.empty()) {
             ++frames_with_bodies_;
@@ -131,9 +130,10 @@ public:
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
         process_last_ts_ = 0;
-        start_ = std::chrono::system_clock::now();
         processed_frames_ = 0;
         frames_with_bodies_ = 0;
+        process_fps_ = 0.0f;
+        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -135,6 +135,7 @@ public:
         frames_with_bodies_ = 0;
         process_fps_ = 0.0f;
         results_.clear();
+        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -45,10 +45,11 @@ class PlottingBodyListener : public vision::BodyListener, public PlottingListene
 
 public:
 
-    PlottingBodyListener(std::ofstream& csv, bool draw_display, bool enable_logging, bool draw_body_id, const
+    template<typename T>
+    PlottingBodyListener(std::ofstream& csv, T& program_options, const
     Duration callback_interval) :
-        PlottingListener(csv, draw_display, enable_logging), callback_interval_(callback_interval),
-        draw_body_id_(draw_body_id), frames_with_bodies_(0) {
+        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging, program_options.write_video), callback_interval_(callback_interval),
+        draw_body_id_(program_options.draw_id), frames_with_bodies_(0) {
 
         out_stream_ << "TimeStamp, bodyId";
 
@@ -74,7 +75,6 @@ public:
     void onBodyResults(const std::map<vision::BodyId, vision::Body>& bodies,
                        vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer();
         results_.emplace_back(frame, bodies);
         ++processed_frames_;
         if (!bodies.empty()) {
@@ -133,9 +133,7 @@ public:
         std::lock_guard<std::mutex> lg(mtx);
         processed_frames_ = 0;
         frames_with_bodies_ = 0;
-        process_fps_ = 0.0f;
         results_.clear();
-        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -74,7 +74,7 @@ public:
     void onBodyResults(const std::map<vision::BodyId, vision::Body>& bodies,
                        vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer(frame.getTimestamp());
+        stopTimer();
         results_.emplace_back(frame, bodies);
         ++processed_frames_;
         if (!bodies.empty()) {
@@ -131,11 +131,9 @@ public:
 
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
-        process_last_ts_ = 0;
         processed_frames_ = 0;
         frames_with_bodies_ = 0;
         process_fps_ = 0.0f;
-        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingBodyListener.h
+++ b/vision/shared/PlottingBodyListener.h
@@ -45,11 +45,9 @@ class PlottingBodyListener : public vision::BodyListener, public PlottingListene
 
 public:
 
-    template<typename T>
-    PlottingBodyListener(std::ofstream& csv, T& program_options, const
+    PlottingBodyListener(std::ofstream& csv, const ProgramOptionsCommon& program_options, const
     Duration callback_interval) :
-        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging, program_options.write_video), callback_interval_(callback_interval),
-        draw_body_id_(program_options.draw_id), frames_with_bodies_(0) {
+        PlottingListener(csv, program_options), callback_interval_(callback_interval) {
 
         out_stream_ << "TimeStamp, bodyId";
 
@@ -77,9 +75,6 @@ public:
         std::lock_guard<std::mutex> lg(mtx);
         results_.emplace_back(frame, bodies);
         ++processed_frames_;
-        if (!bodies.empty()) {
-            ++frames_with_bodies_;
-        }
     };
 
     void outputToFile(const std::map<vision::BodyId, vision::Body>& bodies, double time_stamp) override {
@@ -125,20 +120,12 @@ public:
         image_data_ = viz_.getImageData();
     }
 
-    int getSamplesWithBodiesPercent() const {
-        return (static_cast<float>(frames_with_bodies_) / processed_frames_) * 100;
-    }
-
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
         processed_frames_ = 0;
-        frames_with_bodies_ = 0;
         results_.clear();
     }
 
 private:
     Duration callback_interval_;
-    std::vector<int> body_regions_;
-    bool draw_body_id_;
-    int frames_with_bodies_;
 };

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -198,6 +198,7 @@ public:
         frames_with_faces_ = 0;
         process_fps_ = 0.0f;
         results_.clear();
+        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -10,16 +10,9 @@ using namespace affdex;
 class PlottingImageListener : public vision::ImageListener, public PlottingListener<vision::Face> {
 
 public:
-
-    PlottingImageListener(std::ofstream& csv, ProgramOptionsWebcam& program_options ) :
-        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging), capture_last_ts_(0),
-        capture_fps_(0), draw_face_id_(program_options.draw_id), frames_with_faces_(0),
-        show_drowsiness_(program_options.show_drowsiness) {
-        setCSVHeaders();
-    }
-
-    PlottingImageListener(std::ofstream& csv, ProgramOptionsVideo& program_options ) :
-        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging), capture_last_ts_(0),
+    template<typename T>
+    PlottingImageListener(std::ofstream& csv, T& program_options ) :
+        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging, program_options.write_video), capture_last_ts_(0),
         capture_fps_(0), draw_face_id_(program_options.draw_id), frames_with_faces_(0),
         show_drowsiness_(program_options.show_drowsiness) {
         setCSVHeaders();
@@ -55,7 +48,6 @@ public:
 
     void onImageResults(std::map<vision::FaceId, vision::Face> faces, vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer();
         results_.emplace_back(frame, faces);
         ++processed_frames_;
         if (!faces.empty()) {
@@ -196,9 +188,7 @@ public:
         capture_fps_ = 0;
         processed_frames_ = 0;
         frames_with_faces_ = 0;
-        process_fps_ = 0.0f;
         results_.clear();
-        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -10,9 +10,8 @@ using namespace affdex;
 class PlottingImageListener : public vision::ImageListener, public PlottingListener<vision::Face> {
 
 public:
-    template<typename T>
-    PlottingImageListener(std::ofstream& csv, T& program_options ) :
-        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging, program_options.write_video), capture_last_ts_(0),
+    PlottingImageListener(std::ofstream& csv, const ProgramOptionsCommon& program_options) :
+        PlottingListener(csv, program_options), capture_last_ts_(0),
         capture_fps_(0), draw_face_id_(program_options.draw_id), frames_with_faces_(0),
         show_drowsiness_(program_options.show_drowsiness) {
         setCSVHeaders();
@@ -32,7 +31,7 @@ public:
         out_stream_ << "mood,dominantEmotion,dominantEmotionConfidence,gazeRegion, gazeConfidence,";
         out_stream_ << "identity,identityConfidence,age,ageConfidence,ageCategory,glasses";
 
-        if(show_drowsiness_) {
+        if (show_drowsiness_) {
             out_stream_ << ",drowsinessLevel,drowsinessConfidence";
         }
 
@@ -78,8 +77,8 @@ public:
                 out_stream_ << "nan,";
             }
             // mood,dominantEmotion,dominantEmotionConfidence,gazeRegion, gazeConfidence,identity,identityConfidence,age,ageConfidence,ageCategory,glasses
-            out_stream_<< "nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan";
-            if(show_drowsiness_) {
+            out_stream_ << "nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan";
+            if (show_drowsiness_) {
                 out_stream_ << ",nan,nan";
             }
             out_stream_ << std::endl;
@@ -137,7 +136,7 @@ public:
 
             out_stream_ << "," << f.getGlasses();
 
-            if(show_drowsiness_) {
+            if (show_drowsiness_) {
                 const auto drowsiness_metric = f.getDrowsinessMetric();
                 out_stream_ << "," << viz_.DROWSINESS_LEVELS[drowsiness_metric.drowsiness]
                             << "," << drowsiness_metric.confidence;
@@ -180,7 +179,6 @@ public:
     int getFramesWithFacesPercent() {
         return (static_cast<float>(frames_with_faces_) / processed_frames_) * 100;
     }
-
 
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -55,7 +55,7 @@ public:
 
     void onImageResults(std::map<vision::FaceId, vision::Face> faces, vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer(frame.getTimestamp());
+        stopTimer();
         results_.emplace_back(frame, faces);
         ++processed_frames_;
         if (!faces.empty()) {
@@ -194,11 +194,9 @@ public:
         std::lock_guard<std::mutex> lg(mtx);
         capture_last_ts_ = 0;
         capture_fps_ = 0;
-        process_last_ts_ = 0;
         processed_frames_ = 0;
         frames_with_faces_ = 0;
         process_fps_ = 0.0f;
-        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingImageListener.h
+++ b/vision/shared/PlottingImageListener.h
@@ -175,8 +175,9 @@ public:
             // Draw a face on screen
             viz_.drawFaceMetrics(f, bbox, draw_face_id_, show_drowsiness_);
         }
-
-        viz_.showImage();
+        if (draw_display_) {
+            viz_.showImage();
+        }
         image_data_ = viz_.getImageData();
     }
 

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -24,7 +24,8 @@ public:
         processed_frames_(0),
         logging_enabled_(enable_logging),
         process_fps_(0),
-        total_time_to_process_frames_(0) {
+        total_time_to_process_frames_(0),
+        total_frames_count_(0) {
     }
 
     int getProcessedFrames() {
@@ -66,6 +67,7 @@ public:
     void startTimer() {
         std::lock_guard<std::mutex> lg(mtx);
         begin_ = std::chrono::steady_clock::now();
+        ++total_frames_count_;
     }
 
     void stopTimer() {
@@ -83,6 +85,10 @@ public:
     long getTotalTimeToProcessFrames() {
         //convert from milliseconds to seconds
         return total_time_to_process_frames_ * 1e-3;
+    }
+
+    unsigned int totalFramesCount() {
+        return total_frames_count_;
     }
 
 protected:
@@ -105,4 +111,5 @@ protected:
     std::chrono::steady_clock::time_point begin_;
     std::chrono::steady_clock::time_point end_;
     long total_time_to_process_frames_;
+    unsigned int total_frames_count_;
 };

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -25,7 +25,7 @@ public:
         draw_display_(draw_display),
         processed_frames_(0),
         logging_enabled_(enable_logging),
-        process_fps_(0){
+        process_fps_(0) {
     }
 
     int getProcessedFrames() {
@@ -42,13 +42,11 @@ public:
     virtual void reset() = 0;
 
     void drawRecentFrame() {
-        if (draw_display_) {
-            if (most_recent_frame_.getTimestamp() - time_callback_received_ <= timeout_) {
-                draw(latest_data_.second, most_recent_frame_);
-            }
-            else {
-                draw({}, most_recent_frame_);
-            }
+        if (most_recent_frame_.getTimestamp() - time_callback_received_ <= timeout_) {
+            draw(latest_data_.second, most_recent_frame_);
+        }
+        else {
+            draw({}, most_recent_frame_);
         }
     }
 

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -10,6 +10,8 @@
 #include <condition_variable>
 #include <iostream>
 #include <iomanip>
+#include <chrono>
+
 
 using namespace affdex;
 
@@ -19,11 +21,11 @@ public:
     PlottingListener(std::ofstream& csv, bool draw_display, bool enable_logging) :
         out_stream_(csv),
         image_data_(),
-        start_(std::chrono::system_clock::now()),
         process_last_ts_(0),
         draw_display_(draw_display),
         processed_frames_(0),
-        logging_enabled_(enable_logging) {
+        logging_enabled_(enable_logging),
+        process_fps_(0){
     }
 
     int getProcessedFrames() {
@@ -64,13 +66,41 @@ public:
         drawRecentFrame();
     }
 
+    void startTimer() {
+        std::lock_guard<std::mutex> lg(mtx);
+        begin_ = std::chrono::steady_clock::now();
+    }
+
+    void stopTimer(const Timestamp& timestamp_ms) {
+        end_ = std::chrono::steady_clock::now();
+        const int diff = timestamp_ms - process_last_ts_;
+        if (diff > 0) {
+            instantaneous_fps_ = 1000.0 / diff;
+        }
+        else {
+            instantaneous_fps_ = 0;
+        }
+        process_fps_ = 1000.0 /std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
+        process_last_ts_ = timestamp_ms;
+
+    }
+
+    float getProcessingFrameRate() {
+        std::lock_guard<std::mutex> lg(mtx);
+        return process_fps_;
+    }
+
+    float getInstantaneousFrameRate() {
+        std::lock_guard<std::mutex> lg(mtx);
+        return instantaneous_fps_;
+    }
+
 protected:
     using frame_type_id_pair = std::pair<vision::Frame, std::map<vision::Id, T>>;
     std::ofstream& out_stream_;
     Visualizer viz_;
     cv::Mat image_data_;
 
-    std::chrono::time_point<std::chrono::system_clock> start_;
     std::mutex mtx;
 
     std::deque<frame_type_id_pair> results_;
@@ -82,4 +112,9 @@ protected:
     vision::Frame most_recent_frame_;
     Timestamp time_callback_received_ = 0;
     Duration timeout_ = 500;
+    float process_fps_;
+    float instantaneous_fps_;
+    std::chrono::steady_clock::time_point begin_;
+    std::chrono::steady_clock::time_point end_;
+
 };

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -2,6 +2,7 @@
 
 #include "Visualizer.h"
 #include "Frame.h"
+#include "ProgramOptions.h"
 
 #include <deque>
 #include <mutex>
@@ -15,13 +16,14 @@ using namespace affdex;
 template<typename T> class PlottingListener {
 
 public:
-    PlottingListener(std::ofstream& csv, bool draw_display, bool enable_logging, bool write_video) :
+
+    PlottingListener(std::ofstream& csv, const ProgramOptionsCommon& program_options) :
         out_stream_(csv),
         image_data_(),
-        draw_display_(draw_display),
+        draw_display_(program_options.draw_display),
         processed_frames_(0),
-        logging_enabled_(enable_logging),
-        write_video_(write_video){
+        logging_enabled_(!program_options.disable_logging),
+        write_video_(program_options.write_video) {
     }
 
     int getProcessedFrames() {
@@ -57,7 +59,7 @@ public:
             const auto items = latest_data_.second;
             outputToFile(items, old_frame.getTimestamp());
         }
-        if(write_video_ || draw_display_) {
+        if (write_video_ || draw_display_) {
             drawRecentFrame();
         }
     }
@@ -79,5 +81,4 @@ protected:
     Timestamp time_callback_received_ = 0;
     Duration timeout_ = 500;
     bool write_video_;
-
 };

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "Visualizer.h"
@@ -10,7 +9,6 @@
 #include <condition_variable>
 #include <iostream>
 #include <iomanip>
-#include <chrono>
 
 using namespace affdex;
 

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -20,7 +20,6 @@ public:
     PlottingListener(std::ofstream& csv, bool draw_display, bool enable_logging) :
         out_stream_(csv),
         image_data_(),
-        process_last_ts_(0),
         draw_display_(draw_display),
         processed_frames_(0),
         logging_enabled_(enable_logging),
@@ -69,29 +68,16 @@ public:
         begin_ = std::chrono::steady_clock::now();
     }
 
-    void stopTimer(const Timestamp& timestamp_ms) {
+    void stopTimer() {
         end_ = std::chrono::steady_clock::now();
-        const int diff = timestamp_ms - process_last_ts_;
-        if (diff > 0) {
-            instantaneous_fps_ = 1000.0 / diff;
-        }
-        else {
-            instantaneous_fps_ = 0;
-        }
         const auto timer_diff = std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
         total_time_to_process_frames_ += timer_diff;
         process_fps_ = 1000.0 / timer_diff;
-        process_last_ts_ = timestamp_ms;
     }
 
     float getProcessingFrameRate() {
         std::lock_guard<std::mutex> lg(mtx);
         return process_fps_;
-    }
-
-    float getInstantaneousFrameRate() {
-        std::lock_guard<std::mutex> lg(mtx);
-        return instantaneous_fps_;
     }
 
     long getTotalTimeToProcessFrames() {
@@ -108,7 +94,6 @@ protected:
     std::mutex mtx;
 
     std::deque<frame_type_id_pair> results_;
-    Timestamp process_last_ts_;
     bool draw_display_;
     int processed_frames_;
     bool logging_enabled_;
@@ -117,7 +102,6 @@ protected:
     Timestamp time_callback_received_ = 0;
     Duration timeout_ = 500;
     float process_fps_;
-    float instantaneous_fps_;
     std::chrono::steady_clock::time_point begin_;
     std::chrono::steady_clock::time_point end_;
     long total_time_to_process_frames_;

--- a/vision/shared/PlottingListener.h
+++ b/vision/shared/PlottingListener.h
@@ -12,7 +12,6 @@
 #include <iomanip>
 #include <chrono>
 
-
 using namespace affdex;
 
 template<typename T> class PlottingListener {
@@ -25,7 +24,8 @@ public:
         draw_display_(draw_display),
         processed_frames_(0),
         logging_enabled_(enable_logging),
-        process_fps_(0) {
+        process_fps_(0),
+        total_time_to_process_frames_(0) {
     }
 
     int getProcessedFrames() {
@@ -78,9 +78,10 @@ public:
         else {
             instantaneous_fps_ = 0;
         }
-        process_fps_ = 1000.0 /std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
+        const auto timer_diff = std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
+        total_time_to_process_frames_ += timer_diff;
+        process_fps_ = 1000.0 / timer_diff;
         process_last_ts_ = timestamp_ms;
-
     }
 
     float getProcessingFrameRate() {
@@ -91,6 +92,11 @@ public:
     float getInstantaneousFrameRate() {
         std::lock_guard<std::mutex> lg(mtx);
         return instantaneous_fps_;
+    }
+
+    long getTotalTimeToProcessFrames() {
+        //convert from milliseconds to seconds
+        return total_time_to_process_frames_ * 1e-3;
     }
 
 protected:
@@ -114,5 +120,5 @@ protected:
     float instantaneous_fps_;
     std::chrono::steady_clock::time_point begin_;
     std::chrono::steady_clock::time_point end_;
-
+    long total_time_to_process_frames_;
 };

--- a/vision/shared/PlottingObjectListener.h
+++ b/vision/shared/PlottingObjectListener.h
@@ -39,12 +39,11 @@ public:
 
     void onObjectResults(const std::map<ObjectId, Object>& objects, vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
+        stopTimer(frame.getTimestamp());
         results_.emplace_back(frame, objects);
-        process_last_ts_ = frame.getTimestamp();
-
-        processed_frames_++;
+        ++processed_frames_;
         if (!objects.empty()) {
-            frames_with_objects_++;
+            ++frames_with_objects_;
         }
     };
 
@@ -168,9 +167,10 @@ public:
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
         process_last_ts_ = 0;
-        start_ = std::chrono::system_clock::now();
         processed_frames_ = 0;
         frames_with_objects_ = 0;
+        process_fps_ = 0.0f;
+        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingObjectListener.h
+++ b/vision/shared/PlottingObjectListener.h
@@ -39,7 +39,7 @@ public:
 
     void onObjectResults(const std::map<ObjectId, Object>& objects, vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer(frame.getTimestamp());
+        stopTimer();
         results_.emplace_back(frame, objects);
         ++processed_frames_;
         if (!objects.empty()) {
@@ -168,11 +168,9 @@ public:
 
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
-        process_last_ts_ = 0;
         processed_frames_ = 0;
         frames_with_objects_ = 0;
         process_fps_ = 0.0f;
-        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingObjectListener.h
+++ b/vision/shared/PlottingObjectListener.h
@@ -172,6 +172,7 @@ public:
         frames_with_objects_ = 0;
         process_fps_ = 0.0f;
         results_.clear();
+        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingObjectListener.h
+++ b/vision/shared/PlottingObjectListener.h
@@ -125,7 +125,9 @@ public:
             }
         }
 
-        viz_.showImage();
+        if (draw_display_) {
+            viz_.showImage();
+        }
         image_data_ = viz_.getImageData();
     }
 

--- a/vision/shared/PlottingOccupantListener.h
+++ b/vision/shared/PlottingOccupantListener.h
@@ -114,6 +114,7 @@ public:
         frames_with_occupants_ = 0;
         process_fps_ = 0.0f;
         results_.clear();
+        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingOccupantListener.h
+++ b/vision/shared/PlottingOccupantListener.h
@@ -87,7 +87,9 @@ public:
             }
         }
 
-        viz_.showImage();
+        if (draw_display_) {
+            viz_.showImage();
+        }
         image_data_ = viz_.getImageData();
     }
 

--- a/vision/shared/PlottingOccupantListener.h
+++ b/vision/shared/PlottingOccupantListener.h
@@ -9,10 +9,11 @@ class PlottingOccupantListener : public vision::OccupantListener, public Plottin
 
 public:
 
-    PlottingOccupantListener(std::ofstream& csv, bool draw_display, bool enable_logging, bool draw_occupant_id, const
+    template<typename T>
+    PlottingOccupantListener(std::ofstream& csv, T& program_options, const
     Duration callback_interval, std::vector<CabinRegion> cabin_regions) :
-        PlottingListener(csv, draw_display, enable_logging), callback_interval_(callback_interval),
-        cabin_regions_(std::move(cabin_regions)), draw_occupant_id_(draw_occupant_id), frames_with_occupants_(0) {
+        PlottingListener(csv, program_options.draw_display, !program_options.disable_logging, program_options.write_video), callback_interval_(callback_interval),
+        cabin_regions_(std::move(cabin_regions)), draw_occupant_id_(program_options.draw_id), frames_with_occupants_(0) {
         out_stream_ << "TimeStamp, occupantId, bodyId, confidence, regionId,  upperLeftX, upperLeftY, lowerRightX, "
                        "lowerRightY";
 
@@ -32,7 +33,6 @@ public:
     void onOccupantResults(const std::map<vision::OccupantId, vision::Occupant>& occupants,
                            vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer();
         results_.emplace_back(frame, occupants);
         ++processed_frames_;
         if (!occupants.empty()) {
@@ -112,9 +112,7 @@ public:
         std::lock_guard<std::mutex> lg(mtx);
         processed_frames_ = 0;
         frames_with_occupants_ = 0;
-        process_fps_ = 0.0f;
         results_.clear();
-        total_frames_count_ = 0;
     }
 
 private:

--- a/vision/shared/PlottingOccupantListener.h
+++ b/vision/shared/PlottingOccupantListener.h
@@ -32,7 +32,7 @@ public:
     void onOccupantResults(const std::map<vision::OccupantId, vision::Occupant>& occupants,
                            vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
-        stopTimer(frame.getTimestamp());
+        stopTimer();
         results_.emplace_back(frame, occupants);
         ++processed_frames_;
         if (!occupants.empty()) {
@@ -110,11 +110,9 @@ public:
 
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
-        process_last_ts_ = 0;
         processed_frames_ = 0;
         frames_with_occupants_ = 0;
         process_fps_ = 0.0f;
-        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/PlottingOccupantListener.h
+++ b/vision/shared/PlottingOccupantListener.h
@@ -32,12 +32,11 @@ public:
     void onOccupantResults(const std::map<vision::OccupantId, vision::Occupant>& occupants,
                            vision::Frame frame) override {
         std::lock_guard<std::mutex> lg(mtx);
+        stopTimer(frame.getTimestamp());
         results_.emplace_back(frame, occupants);
-        process_last_ts_ = frame.getTimestamp();
-
-        processed_frames_++;
+        ++processed_frames_;
         if (!occupants.empty()) {
-            frames_with_occupants_++;
+            ++frames_with_occupants_;
         }
     };
 
@@ -110,9 +109,10 @@ public:
     void reset() override {
         std::lock_guard<std::mutex> lg(mtx);
         process_last_ts_ = 0;
-        start_ = std::chrono::system_clock::now();
         processed_frames_ = 0;
         frames_with_occupants_ = 0;
+        process_fps_ = 0.0f;
+        instantaneous_fps_ = 0.0f;
         results_.clear();
     }
 

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -24,6 +24,9 @@ struct ProgramOptionsCommon {
     bool write_video = false;
     bool show_drowsiness = false;
 
+    std::chrono::steady_clock::time_point begin;
+    std::chrono::steady_clock::time_point end;
+
 };
 
 struct ProgramOptionsVideo : ProgramOptionsCommon {

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -16,7 +16,7 @@ struct ProgramOptionsVideo {
     affdex::Path data_dir;
     affdex::Path input_video_path;
     affdex::Path output_video_path;
-    unsigned int sampling_frame_rate;
+    float sampling_frame_rate;
     bool draw_display;
     unsigned int num_faces;
     bool loop = false;

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -4,7 +4,6 @@
 #include "vector"
 #include <opencv2/highgui/highgui.hpp>
 
-
 struct ProgramOptionsCommon {
     enum DetectionType {
         FACE,
@@ -23,6 +22,8 @@ struct ProgramOptionsCommon {
     bool disable_logging = false;
     bool write_video = false;
     bool show_drowsiness = false;
+    bool draw_display = true;
+    bool draw_id;
 };
 
 struct ProgramOptionsVideo : ProgramOptionsCommon {
@@ -30,19 +31,15 @@ struct ProgramOptionsVideo : ProgramOptionsCommon {
     // cmd line args
     affdex::Path input_video_path;
     int sampling_frame_rate;
-    bool draw_display;
     bool loop = false;
-    bool draw_id = false;
 };
 
-struct ProgramOptionsWebcam : ProgramOptionsCommon{
+struct ProgramOptionsWebcam : ProgramOptionsCommon {
     // cmd line args
     affdex::Path output_file_path;
     std::vector<int> resolution;
     float process_framerate;
     int camera_framerate;
     int camera_id;
-    bool draw_display = true;
     bool sync = false;
-    bool draw_id = true;
 };

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -29,7 +29,7 @@ struct ProgramOptionsVideo : ProgramOptionsCommon {
 
     // cmd line args
     affdex::Path input_video_path;
-    float sampling_frame_rate;
+    int sampling_frame_rate;
     bool draw_display;
     bool loop = false;
     bool draw_id = false;

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -23,10 +23,6 @@ struct ProgramOptionsCommon {
     bool disable_logging = false;
     bool write_video = false;
     bool show_drowsiness = false;
-
-    std::chrono::steady_clock::time_point begin;
-    std::chrono::steady_clock::time_point end;
-
 };
 
 struct ProgramOptionsVideo : ProgramOptionsCommon {

--- a/vision/shared/ProgramOptions.h
+++ b/vision/shared/ProgramOptions.h
@@ -5,7 +5,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 
-struct ProgramOptionsVideo {
+struct ProgramOptionsCommon {
     enum DetectionType {
         FACE,
         OBJECT,
@@ -14,43 +14,36 @@ struct ProgramOptionsVideo {
     };
     // cmd line args
     affdex::Path data_dir;
-    affdex::Path input_video_path;
     affdex::Path output_video_path;
-    float sampling_frame_rate;
-    bool draw_display;
+    cv::VideoWriter output_video;
+    DetectionType detection_type = FACE;
+
     unsigned int num_faces;
-    bool loop = false;
-    bool draw_id = false;
+
     bool disable_logging = false;
     bool write_video = false;
     bool show_drowsiness = false;
-    cv::VideoWriter output_video;
-    DetectionType detection_type = FACE;
+
 };
 
-struct ProgramOptionsWebcam {
+struct ProgramOptionsVideo : ProgramOptionsCommon {
 
-    enum DetectionType {
-        FACE,
-        OBJECT,
-        OCCUPANT,
-        BODY
-    };
     // cmd line args
-    affdex::Path data_dir;
+    affdex::Path input_video_path;
+    float sampling_frame_rate;
+    bool draw_display;
+    bool loop = false;
+    bool draw_id = false;
+};
+
+struct ProgramOptionsWebcam : ProgramOptionsCommon{
+    // cmd line args
     affdex::Path output_file_path;
-    affdex::Path output_video_path;
     std::vector<int> resolution;
-    int process_framerate;
+    float process_framerate;
     int camera_framerate;
     int camera_id;
-    unsigned int num_faces;
     bool draw_display = true;
     bool sync = false;
     bool draw_id = true;
-    bool disable_logging = false;
-    bool write_video = false;
-    bool show_drowsiness = false;
-    cv::VideoWriter output_video;
-    DetectionType detection_type = FACE;
 };

--- a/vision/shared/Timer.h
+++ b/vision/shared/Timer.h
@@ -2,18 +2,18 @@
 #include <chrono>
 
 struct Timer{
-    int count_ = 0;
-    long total_elapsed_time_ = 0;
-    std::chrono::steady_clock::time_point begin_;
-    std::chrono::steady_clock::time_point end_;
+    int count = 0;
+    long total_elapsed_time = 0;
+    std::chrono::steady_clock::time_point begin;
+    std::chrono::steady_clock::time_point end;
 
     void startTimer() {
-        begin_ = std::chrono::steady_clock::now();
-        ++count_;
+        begin = std::chrono::steady_clock::now();
+        ++count;
     }
 
     void stopTimer() {
-        end_ = std::chrono::steady_clock::now();
-        total_elapsed_time_ += std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
+        end = std::chrono::steady_clock::now();
+        total_elapsed_time += std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
     }
 };

--- a/vision/shared/Timer.h
+++ b/vision/shared/Timer.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <chrono>
+
+struct Timer{
+    int count_ = 0;
+    long total_elapsed_time_ = 0;
+    std::chrono::steady_clock::time_point begin_;
+    std::chrono::steady_clock::time_point end_;
+
+    void startTimer() {
+        begin_ = std::chrono::steady_clock::now();
+        ++count_;
+    }
+
+    void stopTimer() {
+        end_ = std::chrono::steady_clock::now();
+        total_elapsed_time_ += std::chrono::duration_cast<std::chrono::milliseconds>(end_ - begin_).count();
+    }
+};

--- a/vision/shared/VideoReader.cpp
+++ b/vision/shared/VideoReader.cpp
@@ -5,13 +5,11 @@
 
 using namespace std;
 
-VideoReader::VideoReader(const boost::filesystem::path& file_path, const int sampling_frame_rate)
+VideoReader::VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate)
     : sampling_frame_rate_(sampling_frame_rate) {
 
-    last_timestamp_ms_ =
-        sampling_frame_rate == 0
-        ? -1
-        : (0 - 1000 / sampling_frame_rate); // Initialize so that with sampling, we always process the first frame.
+    // Initialize so that with sampling, we always process the first frame.
+    last_timestamp_ms_ = sampling_frame_rate == 0 ? -1 :(0 - 1000 / sampling_frame_rate);
 
     set<boost::filesystem::path> SUPPORTED_EXTS = {
         // Videos
@@ -90,8 +88,8 @@ bool VideoReader::GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_
 void VideoReader::SniffResolution(const boost::filesystem::path& path,
                                   int& height,
                                   int& width,
-                                  int& fps,
-                                  const int sampling_frame_rate) {
+                                  float& fps,
+                                  float sampling_frame_rate) {
     const unsigned int N_SNIFF_FRAMES = 11;   // Estimate from 10 frame durations by pulling the first 11 frames
 
     VideoReader video(path, sampling_frame_rate);
@@ -114,6 +112,6 @@ void VideoReader::SniffResolution(const boost::filesystem::path& path,
     }
 
     // Divide time by (N_frames - 1) since we're after duration that the frames were on screen
-    fps = ((timestamps.size() - 1) * 1000) / (timestamps[timestamps.size() - 1] - timestamps[0]);
+    fps = ((timestamps.size() - 1) * 1000.0) / (timestamps[timestamps.size() - 1] - timestamps[0]);
 
 }

--- a/vision/shared/VideoReader.cpp
+++ b/vision/shared/VideoReader.cpp
@@ -9,7 +9,7 @@ VideoReader::VideoReader(const boost::filesystem::path& file_path, int sampling_
     : sampling_frame_rate_(sampling_frame_rate) {
 
     // Initialize so that with sampling, we always process the first frame.
-    last_timestamp_ms_ = sampling_frame_rate == 0 ? -1 :(0 - 1000 / sampling_frame_rate);
+    last_timestamp_ms_ = sampling_frame_rate == 0 ? -1 : (0 - 1000 / sampling_frame_rate);
 
     set<boost::filesystem::path> SUPPORTED_EXTS = {
         // Videos
@@ -44,7 +44,7 @@ bool VideoReader::GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms) 
             current_frame_++;
         }
     } while ((sampling_frame_rate_ > 0) && (timestamp_ms > 0) &&
-        ((timestamp_ms - last_timestamp_ms_) < 1000 / sampling_frame_rate_) && frame_data_loaded);
+        ((timestamp_ms - last_timestamp_ms_) < 1000.f / sampling_frame_rate_) && frame_data_loaded);
 
     last_timestamp_ms_ = timestamp_ms;
     frame_progress_->progressed(current_frame_);

--- a/vision/shared/VideoReader.cpp
+++ b/vision/shared/VideoReader.cpp
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-VideoReader::VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate)
+VideoReader::VideoReader(const boost::filesystem::path& file_path, int sampling_frame_rate)
     : sampling_frame_rate_(sampling_frame_rate) {
 
     // Initialize so that with sampling, we always process the first frame.

--- a/vision/shared/VideoReader.cpp
+++ b/vision/shared/VideoReader.cpp
@@ -35,21 +35,19 @@ uint64_t VideoReader::TotalFrames() const {
     return total_frames_;
 }
 
-bool VideoReader::GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms, bool show_progress) {
+bool VideoReader::GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms) {
     bool frame_data_loaded;
 
     do {
         frame_data_loaded = GetFrameData(bgr_frame, timestamp_ms);
-        if (show_progress && frame_data_loaded) {
+        if (frame_data_loaded) {
             current_frame_++;
         }
     } while ((sampling_frame_rate_ > 0) && (timestamp_ms > 0) &&
         ((timestamp_ms - last_timestamp_ms_) < 1000 / sampling_frame_rate_) && frame_data_loaded);
 
     last_timestamp_ms_ = timestamp_ms;
-    if(show_progress) {
-        frame_progress_->progressed(current_frame_);
-    }
+    frame_progress_->progressed(current_frame_);
     return frame_data_loaded;
 }
 
@@ -83,35 +81,4 @@ bool VideoReader::GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_
     }
 
     return frame_found && frame_retrieved;
-}
-
-void VideoReader::SniffResolution(const boost::filesystem::path& path,
-                                  int& height,
-                                  int& width,
-                                  float& fps,
-                                  float sampling_frame_rate) {
-    const unsigned int N_SNIFF_FRAMES = 11;   // Estimate from 10 frame durations by pulling the first 11 frames
-
-    VideoReader video(path, sampling_frame_rate);
-    std::vector<affdex::Timestamp> timestamps;
-    cv::Mat bgr_frame;
-    affdex::Timestamp timestamp_msec;
-    height = width = 0;
-    while (timestamps.size() < N_SNIFF_FRAMES && video.GetFrame(bgr_frame, timestamp_msec, false)) {
-        if (timestamp_msec >= 0) {
-            timestamps.push_back(timestamp_msec);
-        }
-        if (!bgr_frame.empty()) {
-            height = bgr_frame.rows;
-            width = bgr_frame.cols;
-        }
-    }
-
-    if (timestamps.size() < 2) {
-        throw "Unable to estimate fps from input video: " + path.string();
-    }
-
-    // Divide time by (N_frames - 1) since we're after duration that the frames were on screen
-    fps = ((timestamps.size() - 1) * 1000.0) / (timestamps[timestamps.size() - 1] - timestamps[0]);
-
 }

--- a/vision/shared/VideoReader.h
+++ b/vision/shared/VideoReader.h
@@ -8,15 +8,12 @@
 
 class VideoReader {
 public:
-    VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate = 0);
+    explicit VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate = 0);
 
-    bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms, bool show_progress = true);
+    bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
     bool GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
 
     uint64_t TotalFrames() const;
-
-    static void SniffResolution(const boost::filesystem::path& path, int& height, int& width, float& fps,
-                                float sampling_frame_rate = 0);
 
 private:
     cv::VideoCapture cap_;

--- a/vision/shared/VideoReader.h
+++ b/vision/shared/VideoReader.h
@@ -10,7 +10,7 @@ class VideoReader {
 public:
     VideoReader(const boost::filesystem::path& file_path, const int sampling_frame_rate);
 
-    bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
+    bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms, bool show_progress = true);
     bool GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
 
     uint64_t TotalFrames() const;

--- a/vision/shared/VideoReader.h
+++ b/vision/shared/VideoReader.h
@@ -21,7 +21,7 @@ public:
 private:
     cv::VideoCapture cap_;
     affdex::Timestamp last_timestamp_ms_;
-    const int sampling_frame_rate_;
+    float sampling_frame_rate_;
 
     uint64_t total_frames_ = 0;
     uint64_t current_frame_ = 0;

--- a/vision/shared/VideoReader.h
+++ b/vision/shared/VideoReader.h
@@ -8,7 +8,7 @@
 
 class VideoReader {
 public:
-    explicit VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate = 0);
+    explicit VideoReader(const boost::filesystem::path& file_path, int sampling_frame_rate = 0);
 
     bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
     bool GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
@@ -18,7 +18,7 @@ public:
 private:
     cv::VideoCapture cap_;
     affdex::Timestamp last_timestamp_ms_;
-    float sampling_frame_rate_;
+    int sampling_frame_rate_;
 
     uint64_t total_frames_ = 0;
     uint64_t current_frame_ = 0;

--- a/vision/shared/VideoReader.h
+++ b/vision/shared/VideoReader.h
@@ -8,19 +8,19 @@
 
 class VideoReader {
 public:
-    VideoReader(const boost::filesystem::path& file_path, const int sampling_frame_rate);
+    VideoReader(const boost::filesystem::path& file_path, float sampling_frame_rate = 0);
 
     bool GetFrame(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms, bool show_progress = true);
     bool GetFrameData(cv::Mat& bgr_frame, affdex::Timestamp& timestamp_ms);
 
     uint64_t TotalFrames() const;
 
-    static void SniffResolution(const boost::filesystem::path& path, int& height, int& width, int& fps,
-                                const int sampling_frame_rate = 0);
+    static void SniffResolution(const boost::filesystem::path& path, int& height, int& width, float& fps,
+                                float sampling_frame_rate = 0);
 
 private:
     cv::VideoCapture cap_;
-    affdex::Timestamp last_timestamp_ms_ = 0;
+    affdex::Timestamp last_timestamp_ms_;
     const int sampling_frame_rate_;
 
     uint64_t total_frames_ = 0;

--- a/vision/shared/Visualizer.cpp
+++ b/vision/shared/Visualizer.cpp
@@ -114,10 +114,12 @@ Visualizer::Visualizer() :
         {Drowsiness::SEVERE, "SEVERE"},
         {Drowsiness::ASLEEP, "ASLEEP"}
     };
-
 }
 
-void Visualizer::drawFaceMetrics(affdex::vision::Face face, std::vector<Point> bounding_box, bool draw_face_id, bool show_drowsiness) {
+void Visualizer::drawFaceMetrics(affdex::vision::Face face,
+                                 std::vector<Point> bounding_box,
+                                 bool draw_face_id,
+                                 bool show_drowsiness) {
     //Draw Right side metrics
     int padding = bounding_box[0].y; //Top left Y
 
@@ -195,13 +197,19 @@ void Visualizer::drawFaceMetrics(affdex::vision::Face face, std::vector<Point> b
     //Draw glasses confidence
     drawClassifierOutput("glasses", face.getGlasses(), cv::Point(bounding_box[0].x, padding += spacing), true);
 
-    if(show_drowsiness) {
+    if (show_drowsiness) {
         // draw drowsiness metric
         const auto drowsiness_metric = face.getDrowsinessMetric();
-        drawText("drowsiness_level", DROWSINESS_LEVELS[drowsiness_metric.drowsiness], cv::Point(bounding_box[0].x,
-                                                                                                padding += spacing), true);
-        drawText("drowsiness_confidence", std::to_string(drowsiness_metric.confidence), cv::Point(bounding_box[0].x,
-                                                                                                  padding += spacing), true);
+        drawText("drowsiness_level",
+                 DROWSINESS_LEVELS[drowsiness_metric.drowsiness],
+                 cv::Point(bounding_box[0].x,
+                           padding += spacing),
+                 true);
+        drawText("drowsiness_confidence",
+                 std::to_string(drowsiness_metric.confidence),
+                 cv::Point(bounding_box[0].x,
+                           padding += spacing),
+                 true);
     }
 }
 
@@ -209,7 +217,8 @@ void Visualizer::updateImage(const cv::Mat& output_img) {
     img = output_img;
 
     if (!logo_resized) {
-        const double logo_width = (logo.size().width > img.size().width * 0.25 ? img.size().width * 0.25 : logo.size().width);
+        const double
+            logo_width = (logo.size().width > img.size().width * 0.25 ? img.size().width * 0.25 : logo.size().width);
         const double logo_height = ((double)logo_width) * ((double)logo.size().height / logo.size().width);
         cv::resize(logo, logo, cv::Size(logo_width, logo_height));
         logo_resized = true;
@@ -304,19 +313,34 @@ void Visualizer::drawOccupantMetrics(const affdex::vision::Occupant& occupant) {
     int padding = occupant.getBoundingBox().getTopLeft().y; //Top left Y
 
     const std::string id(std::to_string(occupant.getMatchedSeat().cabinRegion.id));
-    const std::string region_type(affdex::vision::CabinRegion::typeToString(occupant.getMatchedSeat().cabinRegion.type));
+    const std::string
+        region_type(affdex::vision::CabinRegion::typeToString(occupant.getMatchedSeat().cabinRegion.type));
     const std::string match_confidence(std::to_string(occupant.getMatchedSeat().matchConfidence));
 
-    drawText("Region Confidence", match_confidence, cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
+    drawText("Region Confidence",
+             match_confidence,
+             cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
              false);
-    drawText("Region " + id, region_type, cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing), false);
-    drawText("ID", std::to_string(occupant.getId()), cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing), false);
+    drawText("Region " + id,
+             region_type,
+             cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
+             false);
+    drawText("ID",
+             std::to_string(occupant.getId()),
+             cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
+             false);
     if (occupant.getFace()) {
-        drawText("FaceID", std::to_string(occupant.getFace()->getId()), cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing), false);
+        drawText("FaceID",
+                 std::to_string(occupant.getFace()->getId()),
+                 cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
+                 false);
 //        drawBoundingBox(occupant.face->getBoundingBox(), {0, 0, 255});
     }
     if (occupant.getBody()) {
-        drawText("BodyID", std::to_string(occupant.getBody()->getId()), cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing), false);
+        drawText("BodyID",
+                 std::to_string(occupant.getBody()->getId()),
+                 cv::Point(occupant.getBoundingBox().getTopLeft().x, padding -= spacing),
+                 false);
         drawBodyMetrics(occupant.getBody()->getBodyPoints());
     }
 }
@@ -348,9 +372,11 @@ void Visualizer::drawObjectMetrics(const affdex::vision::Object& object) {
 
     int padding = object.getBoundingBox().getTopLeft().y; //Top left Y
 
-    drawText("Type", PlottingObjectListener::typeToString(object.getType()), cv::Point(object.getBoundingBox().getTopLeft().x,
-                                                                                  padding -=
-                                                                                      spacing),
+    drawText("Type",
+             PlottingObjectListener::typeToString(object.getType()),
+             cv::Point(object.getBoundingBox().getTopLeft().x,
+                       padding -=
+                           spacing),
              false);
 
     const std::string id(std::to_string(matched_region.cabinRegion.id));


### PR DESCRIPTION
Already approved, was closed due to branch got renamed

removed unused code, fixed casting warnings, refactored ProgramOptions
fixed how we calculate output video fps, and added processed frames per second in final summary
fixed:--draw 0 will write out overlaid video correctly if -o option is specified.
fixed: output overlaid video has same number of frames as input video's frames, and will not skip any frames while processing the video if using default sampling frame rate